### PR TITLE
Update models.py

### DIFF
--- a/sp/models.py
+++ b/sp/models.py
@@ -257,7 +257,7 @@ class IdP(models.Model):
             .not_valid_before(now)
             .not_valid_after(self.certificate_expires)
             .add_extension(basic_contraints, critical=False)
-            .sign(key, hashes.SHA1(), backend)
+            .sign(key, hashes.SHA3_256(), backend)
         )
         self.x509_certificate = cert.public_bytes(serialization.Encoding.PEM).decode(
             "ascii"


### PR DESCRIPTION
SHA1 algorithm is deprecated in Python 3.11.  Updated cert signing algorithm to SHA3_256